### PR TITLE
exclude chef-client from memservice

### DIFF
--- a/resources/attributes/default.rb
+++ b/resources/attributes/default.rb
@@ -44,7 +44,7 @@ default["redborder"]["memory_services"]["n2klocd"] = {"count" => 10, "memory" =>
 default["redborder"]["memory_services"]["k2http"] = {"count" => 10, "memory" => 0 }
 # excluded mem services
 # default['redborder']['excluded_memservices'] = Set.new(['chef-client']) TODO: refactor to this
-default['redborder']['excluded_memservices'] = ['chef-client'] # Don't assign memory to chef because the service will get handled
+default['redborder']['excluded_memory_services'] = ['chef-client'] # Don't assign memory to chef because the service will get handled
 
 default["redborder"]["services"] = {}
 default["redborder"]["services"]["chef-client"]               = true

--- a/resources/attributes/default.rb
+++ b/resources/attributes/default.rb
@@ -42,9 +42,9 @@ default["redborder"]["memory_services"]["f2k"] = { "count" => 40, "memory" => 0 
 default["redborder"]["memory_services"]["redborder-nmsp"] = {"count" => 10, "memory" => 0 }
 default["redborder"]["memory_services"]["n2klocd"] = {"count" => 10, "memory" => 0 }
 default["redborder"]["memory_services"]["k2http"] = {"count" => 10, "memory" => 0 }
-# excluded mem services
-# default['redborder']['excluded_memservices'] = Set.new(['chef-client']) TODO: refactor to this
-default['redborder']['excluded_memory_services'] = ['chef-client'] # Don't assign memory to chef because the service will get handled
+
+# exclude mem services, setting memory to 0 for each.
+default['redborder']['excluded_memory_services'] = ['chef-client']
 
 default["redborder"]["services"] = {}
 default["redborder"]["services"]["chef-client"]               = true

--- a/resources/attributes/default.rb
+++ b/resources/attributes/default.rb
@@ -1,4 +1,4 @@
-require 'set'
+# require 'set' TODO: refactor to this
 #Default attributes
 
 #general
@@ -43,7 +43,8 @@ default["redborder"]["memory_services"]["redborder-nmsp"] = {"count" => 10, "mem
 default["redborder"]["memory_services"]["n2klocd"] = {"count" => 10, "memory" => 0 }
 default["redborder"]["memory_services"]["k2http"] = {"count" => 10, "memory" => 0 }
 # excluded mem services
-default['redborder']['excluded_memservices'] = Set.new(['chef-client']) # Don't assign memory to chef because the service will get handled
+# default['redborder']['excluded_memservices'] = Set.new(['chef-client']) TODO: refactor to this
+default['redborder']['excluded_memservices'] = ['chef-client'] # Don't assign memory to chef because the service will get handled
 
 default["redborder"]["services"] = {}
 default["redborder"]["services"]["chef-client"]               = true

--- a/resources/attributes/default.rb
+++ b/resources/attributes/default.rb
@@ -1,3 +1,4 @@
+require 'set'
 #Default attributes
 
 #general
@@ -41,6 +42,8 @@ default["redborder"]["memory_services"]["f2k"] = { "count" => 40, "memory" => 0 
 default["redborder"]["memory_services"]["redborder-nmsp"] = {"count" => 10, "memory" => 0 }
 default["redborder"]["memory_services"]["n2klocd"] = {"count" => 10, "memory" => 0 }
 default["redborder"]["memory_services"]["k2http"] = {"count" => 10, "memory" => 0 }
+# excluded mem services
+default['redborder']['excluded_memservices'] = Set.new(['chef-client']) # Don't assign memory to chef because the service will get handled
 
 default["redborder"]["services"] = {}
 default["redborder"]["services"]["chef-client"]               = true

--- a/resources/libraries/memory_services.rb
+++ b/resources/libraries/memory_services.rb
@@ -9,7 +9,9 @@ module Rb_proxy
         
         node["redborder"]["memory_services"].each do |name,mem_s|
             if node["redborder"]["services"][name] and !excluded_services.include?(name)
-            memory_services_size = memory_services_size + mem_s["count"] 
+              if !node["redborder"]["excluded_memory_services"].include?(name)
+                memory_services_size = memory_services_size + mem_s["count"] 
+              end
             end
             memory_services_size_total = memory_services_size_total + mem_s["count"]
         end
@@ -24,18 +26,19 @@ module Rb_proxy
         node["redborder"]["memory_services"].each do |name,mem_s|
             
             if node["redborder"]["services"][name] and !excluded_services.include?(name) 
-                    
-            # service count memory assigned * system memory / assigned services memory size
-            memory_serv[name] = (mem_s["count"] * sysmem_total / memory_services_size).round
-            #if the service has a limit of memory, we have to recalculate all using recursivity
-            if !mem_s["max_limit"].nil? and memory_serv[name] > mem_s["max_limit"]
-                memlimit_found = true
-                excluded_services << name
-                #assigning the limit of memory for this service
-                node.default["redborder"]["memory_services"][name]["memory"] = mem_s["max_limit"]
-                #now we have to take off the memory excluded from the total to recalculate memory wihout excluded services by limit
-                sysmem_total_limitsless = sysmem_total - mem_s["max_limit"]
-            end
+                if !node["redborder"]["excluded_memory_services"].include?(name)        
+                    # service count memory assigned * system memory / assigned services memory size
+                    memory_serv[name] = (mem_s["count"] * sysmem_total / memory_services_size).round
+                    #if the service has a limit of memory, we have to recalculate all using recursivity
+                    if !mem_s["max_limit"].nil? and memory_serv[name] > mem_s["max_limit"]
+                        memlimit_found = true
+                        excluded_services << name
+                        #assigning the limit of memory for this service
+                        node.default["redborder"]["memory_services"][name]["memory"] = mem_s["max_limit"]
+                        #now we have to take off the memory excluded from the total to recalculate memory wihout excluded services by limit
+                        sysmem_total_limitsless = sysmem_total - mem_s["max_limit"]
+                    end
+                end
             end
         end
 

--- a/resources/libraries/memory_services.rb
+++ b/resources/libraries/memory_services.rb
@@ -50,4 +50,3 @@ module Rb_proxy
         end
     end
 end
-  

--- a/resources/libraries/memory_services.rb
+++ b/resources/libraries/memory_services.rb
@@ -1,6 +1,6 @@
 module Rb_proxy
     module Helpers
-        def memory_services(sysmem_total, excluded_services)
+        def memory_services(sysmem_total, excluded_services=[])
         memory_serv = {}
         memory_services_size = 0
         memory_services_size_total = 0

--- a/resources/libraries/memory_services.rb
+++ b/resources/libraries/memory_services.rb
@@ -1,6 +1,6 @@
 module Rb_proxy
     module Helpers
-        def memory_services(sysmem_total, excluded_services=[])
+        def memory_services(sysmem_total, excluded_services)
         memory_serv = {}
         memory_services_size = 0
         memory_services_size_total = 0

--- a/resources/recipes/prepare_system.rb
+++ b/resources/recipes/prepare_system.rb
@@ -69,13 +69,4 @@ node.default["redborder"]["zookeeper"]["zk_hosts"] = "zookeeper.service:#{node["
 #getting total system memory less 10% reserved by system
 sysmem_total = (node["memory"]["total"].to_i * 0.90).to_i
 #node attributes related with memory are changed inside the function to have simplicity using recursivity
-memory_services(sysmem_total)
-
-
-
-
-
-
-
-
-
+memory_services(sysmem_total, ['chef-client']) # Don't assign memory to chef because the service will get handled

--- a/resources/recipes/prepare_system.rb
+++ b/resources/recipes/prepare_system.rb
@@ -69,4 +69,4 @@ node.default["redborder"]["zookeeper"]["zk_hosts"] = "zookeeper.service:#{node["
 #getting total system memory less 10% reserved by system
 sysmem_total = (node["memory"]["total"].to_i * 0.90).to_i
 #node attributes related with memory are changed inside the function to have simplicity using recursivity
-memory_services(sysmem_total, node['redborder']['excluded_memservices'])
+memory_services(sysmem_total, node['redborder']['excluded_memory_services'])

--- a/resources/recipes/prepare_system.rb
+++ b/resources/recipes/prepare_system.rb
@@ -69,4 +69,4 @@ node.default["redborder"]["zookeeper"]["zk_hosts"] = "zookeeper.service:#{node["
 #getting total system memory less 10% reserved by system
 sysmem_total = (node["memory"]["total"].to_i * 0.90).to_i
 #node attributes related with memory are changed inside the function to have simplicity using recursivity
-memory_services(sysmem_total, ['chef-client']) # Don't assign memory to chef because the service will get handled
+memory_services(sysmem_total, node['redborder']['excluded_memservices'])

--- a/resources/recipes/prepare_system.rb
+++ b/resources/recipes/prepare_system.rb
@@ -69,4 +69,4 @@ node.default["redborder"]["zookeeper"]["zk_hosts"] = "zookeeper.service:#{node["
 #getting total system memory less 10% reserved by system
 sysmem_total = (node["memory"]["total"].to_i * 0.90).to_i
 #node attributes related with memory are changed inside the function to have simplicity using recursivity
-memory_services(sysmem_total, node['redborder']['excluded_memory_services'])
+memory_services(sysmem_total)


### PR DESCRIPTION
Mirror of cookbook rb manager because chef-client is also part of this kind of machine