### PR TITLE
Release 4.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 cookbook-rb-proxy CHANGELOG
 ===============
 
+## 4.1.2
+
+  - Pablo Pérez
+    - [80ce285] Don't use new methods - use existing methods
+    - [04f160b] Vault sensor info to open the 514 port in rb-firewall
+
 ## 4.1.1
 
   - jnavarrorb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 cookbook-rb-proxy CHANGELOG
 ===============
 
+## 4.1.1
+
+  - jnavarrorb
+    - [5bb11bc] Fix empty string
+
 ## 4.1.0
 
   - nilsver

--- a/resources/metadata.rb
+++ b/resources/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Eneo Tecnología S.L.'
 maintainer_email 'git@redborder.com'
 license          'AGPL-3.0'
 description      'Installs/Configures redborder proxy'
-version          '4.1.1'
+version          '4.1.2'
 
 depends 'rb-common'
 depends 'rb-selinux'

--- a/resources/metadata.rb
+++ b/resources/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Eneo Tecnología S.L.'
 maintainer_email 'git@redborder.com'
 license          'AGPL-3.0'
 description      'Installs/Configures redborder proxy'
-version          '4.1.0'
+version          '4.1.1'
 
 depends 'rb-common'
 depends 'rb-selinux'


### PR DESCRIPTION
Syslog port (514) is open tcp/udp for everybody in public and it should not by @pperezredborder in #73 