### PR TITLE
Bugfix/21816 prepare system loading too long

### DIFF
--- a/resources/recipes/prepare_system.rb
+++ b/resources/recipes/prepare_system.rb
@@ -5,9 +5,10 @@
 
 extend RbProxy::Helpers
 
-# clean metadata to get packages upgrades
-execute 'Clean yum metadata' do
-  command 'yum clean metadata'
+# clean metadata to get packages upgrades, every 24h
+execute 'Clean dnf metadata' do
+  command 'dnf clean metadata && touch /var/cache/dnf/last_makecache'
+  only_if '[ -f /var/cache/dnf/last_makecache ] && [ "$(find /var/cache/dnf/last_makecache -mmin +1440)" ]'
 end
 
 # Stop rb-register


### PR DESCRIPTION
- Added check to clean packages older than 24h. We dont need to clean metadata every 5 minutes.
- Use dnf now instead of yum